### PR TITLE
ci: add concurrency group with cancel-in-progress for PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint (${{ matrix.os }})


### PR DESCRIPTION
## Summary

- Adds a `concurrency` group to the CI workflow so stale PR runs are automatically cancelled when new commits are pushed.
- Push-to-main runs are preserved (cancel-in-progress only applies to pull_request events).

## Problem

The CI workflow triggers on `pull_request` but has no `concurrency` group. When multiple commits are pushed to a PR branch in quick succession, all triggered runs execute to completion. With an 8-job matrix (4 OS × lint + test), each stale run wastes runner minutes across all matrix legs.

## Fix

Added a workflow-level `concurrency` block after `permissions`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

The group key `workflow-ref` ensures each branch gets its own concurrency lane. The conditional `cancel-in-progress` cancels stale PR runs while letting push-to-main runs complete (important for tracking mainline CI state).

## Verification

1. Push two commits in quick succession to a PR branch — first run should be cancelled.
2. Push to `main` — runs should NOT be cancelled.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow concurrency handling to cancel previous pull request runs when new ones are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->