### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,7 @@ jobs:
     if: always()
     needs: [lint]
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Check lint matrix results
         run: |
@@ -55,6 +57,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +80,7 @@ jobs:
     if: always()
     needs: [test]
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Check test matrix results
         run: |

--- a/.github/workflows/go-latest.yml
+++ b/.github/workflows/go-latest.yml
@@ -13,6 +13,7 @@ jobs:
   lint:
     name: Lint (Go Latest, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +40,7 @@ jobs:
   test:
     name: Test (Go Latest, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 20` to all matrix jobs (lint, test) across `ci.yml` and `go-latest.yml`.
- Adds `timeout-minutes: 5` to aggregator jobs (`lint-success`, `test-success`).

## Problem

None of the 6 jobs across both CI workflows set `timeout-minutes`. GitHub Actions defaults to 360 minutes (6 hours). If a test hangs — deadlock under race detection, network call that never returns, `go install` stuck resolving modules — the job burns runner time for hours before being killed.

The Makefile sets `TEST_TIMEOUT=10m` for `go test`, but that doesn't cover `make init-dev` (tool installation) or linting steps, which have no timeout protection at all.

## Fix

Added `timeout-minutes: 20` to each matrix job in both `ci.yml` and `go-latest.yml`. This provides ~4x margin over typical run times, so legitimate runs won't hit it. Aggregator jobs get `timeout-minutes: 5` since they only check matrix results.

**Files changed:**
- `.github/workflows/ci.yml` — 4 jobs (lint, lint-success, test, test-success)
- `.github/workflows/go-latest.yml` — 2 jobs (lint, test)

## Verification

1. CI should pass on this PR with no behavior change (normal runs complete well under 20 minutes).
2. Job timeouts are visible in the GitHub Actions UI job headers.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline configurations with execution time limits to ensure timely job completion and prevent resource exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->